### PR TITLE
fix crash on april fools dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# LazyStronghold
+Lazy evaluation of stronghold generation combined with a multi threading optimisation for faster resets in minecraft speedruns.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.16.1
-yarn_mappings=1.16.1+build.21
+minecraft_version=20w14infinite
+yarn_mappings=20w14infinite+build.4
 loader_version=0.13.3
 # Mod Properties
 mod_version=1.1.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.16.1
 yarn_mappings=1.16.1+build.21
 loader_version=0.13.3
 # Mod Properties
-mod_version=1.1.2
+mod_version=1.1.3
 maven_group=com.gregor0410
 archives_base_name=lazystronghold
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.16.1
 yarn_mappings=1.16.1+build.21
 loader_version=0.13.3
 # Mod Properties
-mod_version=1.1.1
+mod_version=1.1.2
 maven_group=com.gregor0410
 archives_base_name=lazystronghold
 

--- a/src/main/java/com/gregor0410/lazystronghold/IBiomeSource.java
+++ b/src/main/java/com/gregor0410/lazystronghold/IBiomeSource.java
@@ -1,0 +1,7 @@
+package com.gregor0410.lazystronghold;
+
+import net.minecraft.world.biome.source.BiomeSource;
+
+public interface IBiomeSource {
+    BiomeSource copy();
+}

--- a/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
+++ b/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
@@ -30,7 +30,7 @@ public class StrongholdGen implements Runnable {
         this.shouldStop = false;
         this.completedSignal = new AtomicBoolean(false);
         this.seed = seed;
-        this.biomeSource = generator.getBiomeSource().withSeed(seed); //create new biome source instance for thread safety
+        this.biomeSource = ((ChunkGeneratorAccess)generator).getBiomeSource1().withSeed(seed); //create new biome source instance for thread safety
         this.thread = new Thread(this,"Stronghold thread");
         this.config = generator.getConfig().getStronghold();
         this.strongholds = strongholds;

--- a/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
+++ b/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
@@ -1,38 +1,38 @@
 package com.gregor0410.lazystronghold;
 
-import com.gregor0410.lazystronghold.mixin.ChunkGeneratorAccess;
+import com.gregor0410.lazystronghold.mixin.StrongholdFeatureAccess;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.source.BiomeSource;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
-import net.minecraft.world.gen.chunk.StrongholdConfig;
+import net.minecraft.world.gen.feature.StructureFeature;
 import org.apache.logging.log4j.Level;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class StrongholdGen implements Runnable {
-    public final StrongholdConfig config;
     private final Thread thread;
     private final ChunkGenerator generator;
     public final BiomeSource biomeSource;
     private final long seed;
     private ArrayList<Biome> list;
-    public List<ChunkPos> strongholds;
+    public CopyOnWriteArrayList<ChunkPos> strongholds;
     public boolean started;
     public final AtomicBoolean completedSignal;
     public boolean shouldStop;
+    public int count;
 
 
-    public StrongholdGen(ChunkGenerator generator, long seed,List<ChunkPos> strongholds){
+    public StrongholdGen(ChunkGenerator<?> generator, long seed, CopyOnWriteArrayList<ChunkPos> strongholds){
         this.started=false;
         this.shouldStop = false;
         this.completedSignal = new AtomicBoolean(false);
         this.seed = seed;
-        this.biomeSource = ((ChunkGeneratorAccess)generator).getBiomeSource1().withSeed(seed); //create new biome source instance for thread safety
+        this.biomeSource = ((IBiomeSource)generator.getBiomeSource()).copy(); //create new biome source instance for thread safety
         this.thread = new Thread(this,"Stronghold thread");
-        this.config = generator.getConfig().getStronghold();
+        this.count = generator.getConfig().getStrongholdCount();
         this.strongholds = strongholds;
         this.generator = generator;
     }
@@ -46,19 +46,20 @@ public class StrongholdGen implements Runnable {
     @Override
     public void run() {
         Lazystronghold.log(Level.INFO,"Started stronghold gen thread");
-        ((ChunkGeneratorAccess)this.generator).invokeMethod_28509();
+        ((StrongholdFeatureAccess)StructureFeature.STRONGHOLD).invokeInvalidateState();
+        ((StrongholdFeatureAccess)StructureFeature.STRONGHOLD).invokeInitialize(this.generator);
         if(this.shouldStop){
             Lazystronghold.log(Level.INFO,"Stronghold thread stopped early");
         }else {
-            if (this.strongholds.size() != this.config.getCount()) {
+            if (this.strongholds.size() != this.count) {
                 Lazystronghold.log(Level.ERROR, "Only " + this.strongholds.size() + " strongholds generated!");
             } else {
-                Lazystronghold.log(Level.INFO, "Generated " + this.config.getCount() + " strongholds.");
+                Lazystronghold.log(Level.INFO, "Generated " + this.count + " strongholds.");
             }
         }
         synchronized (completedSignal){
             completedSignal.set(true);
-            completedSignal.notify();
+            completedSignal.notifyAll();
         }
     }
 }

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/ChunkGeneratorAccess.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/ChunkGeneratorAccess.java
@@ -1,11 +1,15 @@
 package com.gregor0410.lazystronghold.mixin;
 
+import net.minecraft.world.biome.source.BiomeSource;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Mixin(ChunkGenerator.class)
 public interface ChunkGeneratorAccess {
     @Invoker
     void invokeMethod_28509();
+    @Accessor("biomeSource")
+    BiomeSource getBiomeSource1();
 }

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/ChunkGeneratorMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/ChunkGeneratorMixin.java
@@ -2,61 +2,64 @@ package com.gregor0410.lazystronghold.mixin;
 
 import com.gregor0410.lazystronghold.ChunkGeneratorInterface;
 import com.gregor0410.lazystronghold.StrongholdGen;
+import net.minecraft.structure.StructureManager;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
-import net.minecraft.world.biome.source.BiomeSource;
+import net.minecraft.world.IWorld;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.source.BiomeAccess;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
-import net.minecraft.world.gen.chunk.StructuresConfig;
-import org.objectweb.asm.Opcodes;
+import net.minecraft.world.gen.chunk.ChunkGeneratorConfig;
+import net.minecraft.world.gen.chunk.FlatChunkGenerator;
+import net.minecraft.world.gen.chunk.OverworldChunkGenerator;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 @Mixin(ChunkGenerator.class)
 public class ChunkGeneratorMixin implements ChunkGeneratorInterface {
-    @Shadow @Final private StructuresConfig config;
-    @Shadow @Final private long field_24748;
     @Mutable
-    @Shadow @Final private List<ChunkPos> field_24749;
+    @Shadow @Final protected ChunkGeneratorConfig config;
+    @Shadow @Final protected long seed;
+    @Shadow @Final protected IWorld world;
     private StrongholdGen strongholdGen = null;
-    private final List<ChunkPos> strongholds = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<ChunkPos> strongholds = new CopyOnWriteArrayList<ChunkPos>();
     private static final double ROOT_2 = Math.sqrt(2);
     private static final int PADDING = 10;
 
 
-    @Inject(method="<init>(Lnet/minecraft/world/biome/source/BiomeSource;Lnet/minecraft/world/biome/source/BiomeSource;Lnet/minecraft/world/gen/chunk/StructuresConfig;J)V",at=@At("TAIL"))
+    @Inject(method="<init>",at=@At("TAIL"))
     private void init(CallbackInfo ci){
-        this.field_24749=this.strongholds;
-        if(this.config.getStronghold()!=null){
-            if(this.config.getStronghold().getCount()>0){
-                this.strongholdGen = new StrongholdGen((ChunkGenerator) (Object) this,this.field_24748,this.strongholds);
-            }
+        if(((Object)this instanceof OverworldChunkGenerator || (Object)this instanceof FlatChunkGenerator) && this.config.getStrongholdCount()>0){
+            this.strongholdGen = new StrongholdGen((ChunkGenerator<?>) (Object) this,this.seed,this.strongholds);
         }
     }
 
 
     private int minSquaredDistance(){
-        double d = 2.75 * this.config.getStronghold().getDistance() * 16 - 128 * ROOT_2;
+        double d = 2.75 * this.config.getStrongholdDistance() * 16 - 128 * ROOT_2;
         if(d <0) return 0;
         return (int) Math.pow((int) d >>4,2);
     }
     private int minSquaredDistanceWithPadding(){
-        double d = 2.75 * this.config.getStronghold().getDistance() * 16 - 128 * ROOT_2;
+        double d = 2.75 * this.config.getStrongholdDistance() * 16 - 128 * ROOT_2;
         if(d - PADDING * 16 <0) return 0;
         return (int) Math.pow(((int) d >>4)-PADDING,2);
     }
 
-    @Inject(method="method_28507",at=@At("HEAD"))
-    private void waitForStrongholds(ChunkPos chunkPos, CallbackInfoReturnable<Boolean> cir) throws InterruptedException {
+    @Inject(method="setStructureStarts",at=@At("HEAD"))
+    private void waitForStrongholds(BiomeAccess biomeAccess, Chunk chunk, ChunkGenerator<?> chunkGenerator, StructureManager structureManager, CallbackInfo ci) throws InterruptedException {
         if(this.strongholdGen!=null){
+            ChunkPos chunkPos = chunk.getPos();
             int squaredDistance = (chunkPos.x * chunkPos.x) + (chunkPos.z * chunkPos.z);
             if(squaredDistance >=minSquaredDistanceWithPadding()) {
                 if (!strongholdGen.started) strongholdGen.start();
@@ -71,9 +74,9 @@ public class ChunkGeneratorMixin implements ChunkGeneratorInterface {
         }
     }
 
-    @Redirect(method="locateStructure",at=@At(value="INVOKE",target = "Lnet/minecraft/world/gen/chunk/ChunkGenerator;method_28509()V"))
-    private void waitForStrongholds2(ChunkGenerator instance) throws InterruptedException {
-        if(this.strongholdGen!=null){
+    @Inject(method="locateStructure",at=@At("HEAD"))
+    private void waitForStrongholds2(World world, String id, BlockPos center, int radius, boolean skipExistingChunks, CallbackInfoReturnable<BlockPos> cir) throws InterruptedException {
+        if(Objects.equals(id, "Stronghold") && this.strongholdGen!=null){
             if(!strongholdGen.started)strongholdGen.start();
             synchronized (strongholdGen.completedSignal){
                 while(!strongholdGen.completedSignal.get()){
@@ -83,22 +86,6 @@ public class ChunkGeneratorMixin implements ChunkGeneratorInterface {
         }
     }
 
-
-    @Redirect(method="method_28509",at=@At(value="FIELD",target = "Lnet/minecraft/world/gen/chunk/ChunkGenerator;biomeSource:Lnet/minecraft/world/biome/source/BiomeSource;",opcode = Opcodes.GETFIELD))
-    private BiomeSource getBiomeSource(ChunkGenerator instance){
-        return this.strongholdGen.biomeSource;
-    }
-    @Inject(method = "method_28509",at=@At(value="JUMP",ordinal = 6), cancellable = true)
-    private void stopGenOnLeave(CallbackInfo ci){
-        if(this.strongholdGen!=null){
-            if(this.strongholdGen.shouldStop){
-                ci.cancel();
-            }
-        }
-    }
-    @Redirect(method = "method_28507",at=@At(value = "INVOKE",target = "Lnet/minecraft/world/gen/chunk/ChunkGenerator;method_28509()V"))
-    private void cancelStrongholdGen(ChunkGenerator instance){
-    }
 
     @Override
     public StrongholdGen getStrongholdGen() {

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/EntityMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/EntityMixin.java
@@ -6,7 +6,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.world.World;
-import net.minecraft.world.dimension.DimensionType;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -21,7 +20,7 @@ public abstract class EntityMixin {
     @Inject(method="setWorld",at=@At("HEAD"))
     private void startStrongholdGen(World world, CallbackInfo ci){
         //start stronghold gen on nether entry to prevent lag when throwing eyes
-        if(world.getDimensionRegistryKey()!= DimensionType.OVERWORLD_REGISTRY_KEY&&world instanceof ServerWorld) {
+        if(world.getDimension().isNether() &&world instanceof ServerWorld) {
             MinecraftServer server = this.getServer();
             if(server!=null) {
                 for (ServerWorld serverWorld : server.getWorlds()) {

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/FixedBiomeSourceMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/FixedBiomeSourceMixin.java
@@ -1,0 +1,25 @@
+package com.gregor0410.lazystronghold.mixin;
+
+import com.gregor0410.lazystronghold.IBiomeSource;
+import net.minecraft.world.biome.source.BiomeSource;
+import net.minecraft.world.biome.source.FixedBiomeSource;
+import net.minecraft.world.biome.source.FixedBiomeSourceConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(FixedBiomeSource.class)
+public class FixedBiomeSourceMixin implements IBiomeSource {
+
+    private FixedBiomeSourceConfig config;
+
+    @Inject(method="<init>",at=@At("TAIL"))
+    private void init(FixedBiomeSourceConfig config, CallbackInfo ci){
+        this.config = config;
+    }
+    @Override
+    public BiomeSource copy() {
+        return new FixedBiomeSource(this.config) ;
+    }
+}

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/MinecraftServerMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/MinecraftServerMixin.java
@@ -50,7 +50,7 @@ public class MinecraftServerMixin {
         }
     }
 
-    @Inject(method="prepareStartRegion",at=@At("HEAD"))
+    @Inject(method="prepareStartRegion",at=@At("TAIL"))
     private void waitForStrongholdThreadIfNotNewWorld(CallbackInfo ci){
         if(!this.isNewWorld){
             this.worlds.values().forEach(world->{

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/MultiNoiseBiomeSourceMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/MultiNoiseBiomeSourceMixin.java
@@ -1,0 +1,26 @@
+package com.gregor0410.lazystronghold.mixin;
+
+import com.gregor0410.lazystronghold.IBiomeSource;
+import net.minecraft.world.biome.source.BiomeSource;
+import net.minecraft.world.biome.source.MultiNoiseBiomeSource;
+import net.minecraft.world.biome.source.MultiNoiseBiomeSourceConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MultiNoiseBiomeSource.class)
+public class MultiNoiseBiomeSourceMixin implements IBiomeSource {
+
+    private MultiNoiseBiomeSourceConfig config;
+
+    @Inject(method="<init>",at=@At("TAIL"))
+    private void init(MultiNoiseBiomeSourceConfig config, CallbackInfo ci){
+        this.config = config;
+    }
+    @Override
+    public BiomeSource copy() {
+        return new MultiNoiseBiomeSource(this.config) ;
+    }
+
+}

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/StrongholdFeatureAccess.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/StrongholdFeatureAccess.java
@@ -1,0 +1,14 @@
+package com.gregor0410.lazystronghold.mixin;
+
+import net.minecraft.world.gen.chunk.ChunkGenerator;
+import net.minecraft.world.gen.feature.StrongholdFeature;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(StrongholdFeature.class)
+public interface StrongholdFeatureAccess {
+    @Invoker
+    void invokeInitialize(ChunkGenerator<?> chunkGenerator);
+    @Invoker
+    void invokeInvalidateState();
+}

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/StrongholdFeatureMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/StrongholdFeatureMixin.java
@@ -1,0 +1,89 @@
+package com.gregor0410.lazystronghold.mixin;
+
+import com.gregor0410.lazystronghold.ChunkGeneratorInterface;
+import com.gregor0410.lazystronghold.StrongholdGen;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.source.BiomeAccess;
+import net.minecraft.world.biome.source.BiomeSource;
+import net.minecraft.world.gen.chunk.ChunkGenerator;
+import net.minecraft.world.gen.chunk.ChunkGeneratorConfig;
+import net.minecraft.world.gen.feature.StrongholdFeature;
+import org.jetbrains.annotations.Nullable;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Random;
+
+@Mixin(StrongholdFeature.class)
+public class StrongholdFeatureMixin {
+    @Shadow private ChunkPos[] startPositions;
+    private ChunkGenerator<?> generator;
+
+    @Inject(method="shouldStartAt",at=@At("HEAD"),cancellable = true)
+    private void shouldStartAt(BiomeAccess biomeAccess, ChunkGenerator<?> chunkGenerator, Random random, int chunkZ, int i, Biome biome, CallbackInfoReturnable<Boolean> cir){
+        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) chunkGenerator).getStrongholdGen();
+        if(strongholdGen != null&&strongholdGen.completedSignal.get()){
+            this.startPositions = strongholdGen.strongholds.toArray(this.startPositions);
+        }else{
+            cir.setReturnValue(false);
+        }
+    }
+
+    @Inject(method = "locateStructure",at=@At("HEAD"))
+    private void setStartPositions(World world, ChunkGenerator<? extends ChunkGeneratorConfig> chunkGenerator, BlockPos blockPos, int i, boolean skipExistingChunks, CallbackInfoReturnable<@Nullable BlockPos> cir){
+        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) chunkGenerator).getStrongholdGen();
+        if(strongholdGen != null&&strongholdGen.completedSignal.get()){
+            this.startPositions = strongholdGen.strongholds.toArray(this.startPositions);
+        }
+    }
+
+
+    @Redirect(method="shouldStartAt",at=@At(value="INVOKE",target="Lnet/minecraft/world/gen/feature/StrongholdFeature;initialize(Lnet/minecraft/world/gen/chunk/ChunkGenerator;)V"))
+    private void cancelStrongholdGen(StrongholdFeature instance, ChunkGenerator<?> chunkGenerator){}
+
+    @Redirect(method="locateStructure",at=@At(value="INVOKE",target = "Lnet/minecraft/world/gen/feature/StrongholdFeature;initialize(Lnet/minecraft/world/gen/chunk/ChunkGenerator;)V"))
+    private void cancelStrongholdGen2(StrongholdFeature instance, ChunkGenerator<?> chunkGenerator){}
+
+    @Inject(method="initialize",at=@At("HEAD"))
+    private void setGenerator(ChunkGenerator<?> chunkGenerator, CallbackInfo ci){
+        this.generator = chunkGenerator;
+    }
+
+    @Redirect(method="initialize",at=@At(value="FIELD",opcode=Opcodes.GETFIELD,args="array=set",target = "Lnet/minecraft/world/gen/feature/StrongholdFeature;startPositions:[Lnet/minecraft/util/math/ChunkPos;"))
+    private void addToStrongholds(ChunkPos[] array, int index, ChunkPos value){
+        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) this.generator).getStrongholdGen();
+        if(strongholdGen!=null) {
+            strongholdGen.strongholds.add(value);
+        }
+    }
+
+    @Redirect(method="initialize",at=@At(value="INVOKE",target="Lnet/minecraft/world/gen/chunk/ChunkGenerator;getBiomeSource()Lnet/minecraft/world/biome/source/BiomeSource;"))
+    private BiomeSource getBiomeSource(ChunkGenerator<?> instance){
+        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) this.generator).getStrongholdGen();
+        if(strongholdGen!=null){
+            return strongholdGen.biomeSource;
+        }else{
+            return instance.getBiomeSource(); //this should never be executed but i've left it in to prevent crashing
+        }
+    }
+
+    @Inject(method="initialize",at=@At(value="INVOKE",target = "Lnet/minecraft/world/biome/source/BiomeSource;locateBiome(IIIILjava/util/List;Ljava/util/Random;)Lnet/minecraft/util/math/BlockPos;"),cancellable = true)
+    private void stopStrongholdGen(ChunkGenerator<?> chunkGenerator, CallbackInfo ci){
+        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) this.generator).getStrongholdGen();
+        if(strongholdGen!=null&& strongholdGen.shouldStop){
+            ci.cancel();
+        }
+    }
+
+
+
+}

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/VanillaLayeredBiomeSourceMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/VanillaLayeredBiomeSourceMixin.java
@@ -1,0 +1,26 @@
+package com.gregor0410.lazystronghold.mixin;
+
+import com.gregor0410.lazystronghold.IBiomeSource;
+import net.minecraft.world.biome.source.BiomeSource;
+import net.minecraft.world.biome.source.VanillaLayeredBiomeSource;
+import net.minecraft.world.biome.source.VanillaLayeredBiomeSourceConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(VanillaLayeredBiomeSource.class)
+public class VanillaLayeredBiomeSourceMixin implements IBiomeSource {
+
+    private VanillaLayeredBiomeSourceConfig config;
+
+    @Inject(method="<init>",at=@At("TAIL"))
+    private void init(VanillaLayeredBiomeSourceConfig config, CallbackInfo ci){
+        this.config = config;
+    }
+
+    @Override
+    public BiomeSource copy() {
+        return new VanillaLayeredBiomeSource(this.config);
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,6 +19,6 @@
   ],
   "depends": {
     "fabricloader": ">=0.10.0",
-    "minecraft": "1.16.x"
+    "minecraft": ">=1.15 <=1.16-alpha.20.13.inf"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,8 +3,8 @@
   "id": "lazystronghold",
   "version": "${version}",
   "name": "Lazystronghold",
-  "description": "",
-  "authors": [],
+  "description": "Speeds up stronghold generation through lazy evaluation of strongholds combined with multithreading",
+  "authors": ["Gregor0410"],
   "contact": {},
   "license": "MIT",
   "icon": "assets/lazystronghold/icon.png",
@@ -19,6 +19,6 @@
   ],
   "depends": {
     "fabricloader": ">=0.10.0",
-    "minecraft": "1.16.1"
+    "minecraft": "1.16.x"
   }
 }

--- a/src/main/resources/lazystronghold.mixins.json
+++ b/src/main/resources/lazystronghold.mixins.json
@@ -4,10 +4,14 @@
   "package": "com.gregor0410.lazystronghold.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-    "ChunkGeneratorAccess",
     "ChunkGeneratorMixin",
     "EntityMixin",
-    "MinecraftServerMixin"
+    "FixedBiomeSourceMixin",
+    "MinecraftServerMixin",
+    "MultiNoiseBiomeSourceMixin",
+    "StrongholdFeatureAccess",
+    "StrongholdFeatureMixin",
+    "VanillaLayeredBiomeSourceMixin"
   ],
   "client": [
   ],


### PR DESCRIPTION
the custom april fools dimensions use a MultiNoiseBiomeSource instead of a FixedBiomeSource which is why it crashed

the commit looks like a lot more because i accidentally commited the 20w14infinite version on the 1.16 instead of 1.15 version but its really just the MultiNoiseBiomeSourceMixin (and gradle.properties but whatever)