### PR TITLE
BiomeSource Copy Optimizations & some upgradling+formatting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.10-SNAPSHOT'
+    id 'fabric-loom' version '1.7-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -7,24 +7,13 @@ version = project.mod_version
 group = project.maven_group
 
 repositories {
-    // Add repositories to retrieve artifacts from in here.
-    // You should only use this when depending on other mods because
-    // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
-    // See https://docs.gradle.org/current/userguide/declaring_repositories.html
-    // for more information about repositories.
-}
-
-configurations {
-    modIncludeImplementation
-
-    include.extendsFrom modIncludeImplementation
-    modImplementation.extendsFrom modIncludeImplementation
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+    mappings "dev.tildejustin:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
 minecraft_version=1.16.1
-yarn_mappings=1.16.1+build.21
-loader_version=0.13.3
+yarn_mappings=1.16.1-build.24
+loader_version=0.16.9
 # Mod Properties
 mod_version=1.1.3
 maven_group=com.gregor0410

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/gregor0410/lazystronghold/ChunkGeneratorInterface.java
+++ b/src/main/java/com/gregor0410/lazystronghold/ChunkGeneratorInterface.java
@@ -1,5 +1,5 @@
 package com.gregor0410.lazystronghold;
 
 public interface ChunkGeneratorInterface {
-    StrongholdGen getStrongholdGen();
+    StrongholdGen lazyStronghold$getStrongholdGen();
 }

--- a/src/main/java/com/gregor0410/lazystronghold/Lazystronghold.java
+++ b/src/main/java/com/gregor0410/lazystronghold/Lazystronghold.java
@@ -8,10 +8,12 @@ import org.apache.logging.log4j.Logger;
 public class Lazystronghold implements ModInitializer {
     private static final String MOD_NAME = "LazyStronghold";
     public static Logger LOGGER = LogManager.getLogger();
+
     @Override
     public void onInitialize() {
 
     }
+
     public static void log(Level level, String message) {
         LOGGER.log(level, "[" + MOD_NAME + "] " + message);
     }

--- a/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
+++ b/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
@@ -46,7 +46,7 @@ public class StrongholdGen implements Runnable {
     @Override
     public void run() {
         Lazystronghold.log(Level.INFO,"Started stronghold gen thread");
-        ((ChunkGeneratorAccess)this.generator).invokeMethod_28509();
+        ((ChunkGeneratorAccess)this.generator).callGenerateStrongholdPositions();
         if(this.shouldStop){
             Lazystronghold.log(Level.INFO,"Stronghold thread stopped early");
         }else {

--- a/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
+++ b/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
@@ -24,39 +24,41 @@ public class StrongholdGen implements Runnable {
     public final AtomicBoolean completedSignal;
     public boolean shouldStop;
 
-
-    public StrongholdGen(ChunkGenerator generator, long seed,List<ChunkPos> strongholds){
-        this.started=false;
+    public StrongholdGen(ChunkGenerator generator, long seed, List<ChunkPos> strongholds) {
+        this.started = false;
         this.shouldStop = false;
         this.completedSignal = new AtomicBoolean(false);
         this.seed = seed;
-        this.biomeSource = ((ChunkGeneratorAccess)generator).getBiomeSource1().withSeed(seed); //create new biome source instance for thread safety
-        this.thread = new Thread(this,"Stronghold thread");
+        this.biomeSource = ((ChunkGeneratorAccess) generator).getBiomeSource1().withSeed(seed); //create new biome source instance for thread safety
+        this.thread = new Thread(this, "Stronghold thread");
         this.config = generator.getConfig().getStronghold();
         this.strongholds = strongholds;
         this.generator = generator;
     }
-    public void start(){
+
+    public void start() {
         this.started = true;
         this.thread.start();
     }
-    public void stop(){
-        this.shouldStop=true;
+
+    public void stop() {
+        this.shouldStop = true;
     }
+
     @Override
     public void run() {
-        Lazystronghold.log(Level.INFO,"Started stronghold gen thread");
-        ((ChunkGeneratorAccess)this.generator).callGenerateStrongholdPositions();
-        if(this.shouldStop){
-            Lazystronghold.log(Level.INFO,"Stronghold thread stopped early");
-        }else {
+        Lazystronghold.log(Level.INFO, "Started stronghold gen thread");
+        ((ChunkGeneratorAccess) this.generator).callGenerateStrongholdPositions();
+        if (this.shouldStop) {
+            Lazystronghold.log(Level.INFO, "Stronghold thread stopped early");
+        } else {
             if (this.strongholds.size() != this.config.getCount()) {
                 Lazystronghold.log(Level.ERROR, "Only " + this.strongholds.size() + " strongholds generated!");
             } else {
                 Lazystronghold.log(Level.INFO, "Generated " + this.config.getCount() + " strongholds.");
             }
         }
-        synchronized (completedSignal){
+        synchronized (completedSignal) {
             completedSignal.set(true);
             completedSignal.notify();
         }

--- a/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
+++ b/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
@@ -59,5 +59,6 @@ public class StrongholdGen implements Runnable {
             completedSignal.set(true);
             completedSignal.notify();
         }
+        this.biomeSource = null;
     }
 }

--- a/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
+++ b/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
@@ -2,13 +2,11 @@ package com.gregor0410.lazystronghold;
 
 import com.gregor0410.lazystronghold.mixin.ChunkGeneratorAccess;
 import net.minecraft.util.math.ChunkPos;
-import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.source.BiomeSource;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
 import net.minecraft.world.gen.chunk.StrongholdConfig;
 import org.apache.logging.log4j.Level;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -16,9 +14,8 @@ public class StrongholdGen implements Runnable {
     public final StrongholdConfig config;
     private final Thread thread;
     private final ChunkGenerator generator;
-    public final BiomeSource biomeSource;
     private final long seed;
-    private ArrayList<Biome> list;
+    public BiomeSource biomeSource;
     public List<ChunkPos> strongholds;
     public boolean started;
     public final AtomicBoolean completedSignal;
@@ -29,7 +26,6 @@ public class StrongholdGen implements Runnable {
         this.shouldStop = false;
         this.completedSignal = new AtomicBoolean(false);
         this.seed = seed;
-        this.biomeSource = ((ChunkGeneratorAccess) generator).getBiomeSource1().withSeed(seed); //create new biome source instance for thread safety
         this.thread = new Thread(this, "Stronghold thread");
         this.config = generator.getConfig().getStronghold();
         this.strongholds = strongholds;
@@ -38,6 +34,7 @@ public class StrongholdGen implements Runnable {
 
     public void start() {
         this.started = true;
+        this.biomeSource = ((ChunkGeneratorAccess) this.generator).getBiomeSource1().withSeed(this.seed); //create new biome source instance for thread safety
         this.thread.start();
     }
 

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/ChunkGeneratorAccess.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/ChunkGeneratorAccess.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 @Mixin(ChunkGenerator.class)
 public interface ChunkGeneratorAccess {
     @Invoker
-    void invokeMethod_28509();
+    void callGenerateStrongholdPositions();
     @Accessor("biomeSource")
     BiomeSource getBiomeSource1();
 }

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/ChunkGeneratorAccess.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/ChunkGeneratorAccess.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 public interface ChunkGeneratorAccess {
     @Invoker
     void callGenerateStrongholdPositions();
+
     @Accessor("biomeSource")
     BiomeSource getBiomeSource1();
 }

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/ChunkGeneratorMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/ChunkGeneratorMixin.java
@@ -7,10 +7,7 @@ import net.minecraft.world.biome.source.BiomeSource;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
 import net.minecraft.world.gen.chunk.StructuresConfig;
 import org.objectweb.asm.Opcodes;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Mutable;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -21,48 +18,49 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 @Mixin(ChunkGenerator.class)
-public class ChunkGeneratorMixin implements ChunkGeneratorInterface {
-    @Shadow @Final private StructuresConfig structuresConfig;
-    @Shadow @Final private long seed;
-    @Mutable
-    @Shadow @Final private List<ChunkPos> strongholdPositions;
-    private StrongholdGen strongholdGen = null;
-    private final List<ChunkPos> strongholds = new CopyOnWriteArrayList<>();
+public abstract class ChunkGeneratorMixin implements ChunkGeneratorInterface {
+    @Unique
     private static final double ROOT_2 = Math.sqrt(2);
+    @Unique
     private static final int PADDING = 10;
 
+    @Shadow
+    @Final
+    private StructuresConfig structuresConfig;
 
-    @Inject(method="<init>(Lnet/minecraft/world/biome/source/BiomeSource;Lnet/minecraft/world/biome/source/BiomeSource;Lnet/minecraft/world/gen/chunk/StructuresConfig;J)V",at=@At("TAIL"))
-    private void init(CallbackInfo ci){
-        this.strongholdPositions=this.strongholds;
-        if(this.structuresConfig.getStronghold()!=null){
-            if(this.structuresConfig.getStronghold().getCount()>0){
-                this.strongholdGen = new StrongholdGen((ChunkGenerator) (Object) this,this.seed,this.strongholds);
+    @Shadow
+    @Final
+    private long seed;
+
+    @Mutable
+    @Shadow
+    @Final
+    private List<ChunkPos> strongholdPositions;
+
+    @Unique
+    private StrongholdGen strongholdGen = null;
+    @Unique
+    private final List<ChunkPos> strongholds = new CopyOnWriteArrayList<>();
+
+    @Inject(method = "<init>(Lnet/minecraft/world/biome/source/BiomeSource;Lnet/minecraft/world/biome/source/BiomeSource;Lnet/minecraft/world/gen/chunk/StructuresConfig;J)V", at = @At("TAIL"))
+    private void init(CallbackInfo ci) {
+        this.strongholdPositions = this.strongholds;
+        if (this.structuresConfig.getStronghold() != null) {
+            if (this.structuresConfig.getStronghold().getCount() > 0) {
+                this.strongholdGen = new StrongholdGen((ChunkGenerator) (Object) this, this.seed, this.strongholds);
             }
         }
     }
 
-
-    private int minSquaredDistance(){
-        double d = 2.75 * this.structuresConfig.getStronghold().getDistance() * 16 - 128 * ROOT_2;
-        if(d <0) return 0;
-        return (int) Math.pow((int) d >>4,2);
-    }
-    private int minSquaredDistanceWithPadding(){
-        double d = 2.75 * this.structuresConfig.getStronghold().getDistance() * 16 - 128 * ROOT_2;
-        if(d - PADDING * 16 <0) return 0;
-        return (int) Math.pow(((int) d >>4)-PADDING,2);
-    }
-
-    @Inject(method="isStrongholdAt",at=@At("HEAD"))
+    @Inject(method = "isStrongholdAt", at = @At("HEAD"))
     private void waitForStrongholds(ChunkPos chunkPos, CallbackInfoReturnable<Boolean> cir) throws InterruptedException {
-        if(this.strongholdGen!=null){
+        if (this.strongholdGen != null) {
             int squaredDistance = (chunkPos.x * chunkPos.x) + (chunkPos.z * chunkPos.z);
-            if(squaredDistance >=minSquaredDistanceWithPadding()) {
+            if (squaredDistance >= minSquaredDistanceWithPadding()) {
                 if (!strongholdGen.started) strongholdGen.start();
-                if(squaredDistance>=minSquaredDistance()){
-                    synchronized (strongholdGen.completedSignal){
-                        while(!strongholdGen.completedSignal.get()){
+                if (squaredDistance >= minSquaredDistance()) {
+                    synchronized (strongholdGen.completedSignal) {
+                        while (!strongholdGen.completedSignal.get()) {
                             strongholdGen.completedSignal.wait();
                         }
                     }
@@ -71,38 +69,52 @@ public class ChunkGeneratorMixin implements ChunkGeneratorInterface {
         }
     }
 
-    @Redirect(method="locateStructure",at=@At(value="INVOKE",target = "Lnet/minecraft/world/gen/chunk/ChunkGenerator;generateStrongholdPositions()V"))
+    @Redirect(method = "locateStructure", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/gen/chunk/ChunkGenerator;generateStrongholdPositions()V"))
     private void waitForStrongholds2(ChunkGenerator instance) throws InterruptedException {
-        if(this.strongholdGen!=null){
-            if(!strongholdGen.started)strongholdGen.start();
-            synchronized (strongholdGen.completedSignal){
-                while(!strongholdGen.completedSignal.get()){
+        if (this.strongholdGen != null) {
+            if (!strongholdGen.started) strongholdGen.start();
+            synchronized (strongholdGen.completedSignal) {
+                while (!strongholdGen.completedSignal.get()) {
                     strongholdGen.completedSignal.wait();
                 }
             }
         }
     }
 
-
-    @Redirect(method="generateStrongholdPositions",at=@At(value="FIELD",target = "Lnet/minecraft/world/gen/chunk/ChunkGenerator;biomeSource:Lnet/minecraft/world/biome/source/BiomeSource;",opcode = Opcodes.GETFIELD))
-    private BiomeSource getBiomeSource(ChunkGenerator instance){
+    @Redirect(method = "generateStrongholdPositions", at = @At(value = "FIELD", target = "Lnet/minecraft/world/gen/chunk/ChunkGenerator;biomeSource:Lnet/minecraft/world/biome/source/BiomeSource;", opcode = Opcodes.GETFIELD))
+    private BiomeSource getBiomeSource(ChunkGenerator instance) {
         return this.strongholdGen.biomeSource;
     }
-    @Inject(method = "generateStrongholdPositions",at=@At(value="JUMP",ordinal = 6), cancellable = true)
-    private void stopGenOnLeave(CallbackInfo ci){
-        if(this.strongholdGen!=null){
-            if(this.strongholdGen.shouldStop){
+
+    @Inject(method = "generateStrongholdPositions", at = @At(value = "JUMP", ordinal = 6), cancellable = true)
+    private void stopGenOnLeave(CallbackInfo ci) {
+        if (this.strongholdGen != null) {
+            if (this.strongholdGen.shouldStop) {
                 ci.cancel();
             }
         }
     }
-    @Redirect(method = "isStrongholdAt",at=@At(value = "INVOKE",target = "Lnet/minecraft/world/gen/chunk/ChunkGenerator;generateStrongholdPositions()V"))
-    private void cancelStrongholdGen(ChunkGenerator instance){
+
+    @Redirect(method = "isStrongholdAt", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/gen/chunk/ChunkGenerator;generateStrongholdPositions()V"))
+    private void cancelStrongholdGen(ChunkGenerator instance) {
     }
 
     @Override
-    public StrongholdGen getStrongholdGen() {
+    public StrongholdGen lazyStronghold$getStrongholdGen() {
         return this.strongholdGen;
     }
 
+    @Unique
+    private int minSquaredDistance() {
+        double d = 2.75 * this.structuresConfig.getStronghold().getDistance() * 16 - 128 * ROOT_2;
+        if (d < 0) return 0;
+        return (int) Math.pow((int) d >> 4, 2);
+    }
+
+    @Unique
+    private int minSquaredDistanceWithPadding() {
+        double d = 2.75 * this.structuresConfig.getStronghold().getDistance() * 16 - 128 * ROOT_2;
+        if (d - PADDING * 16 < 0) return 0;
+        return (int) Math.pow(((int) d >> 4) - PADDING, 2);
+    }
 }

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/EntityMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/EntityMixin.java
@@ -16,16 +16,17 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Entity.class)
 public abstract class EntityMixin {
-    @Shadow public abstract @Nullable MinecraftServer getServer();
+    @Shadow
+    public abstract @Nullable MinecraftServer getServer();
 
-    @Inject(method="setWorld",at=@At("HEAD"))
-    private void startStrongholdGen(World world, CallbackInfo ci){
+    @Inject(method = "setWorld", at = @At("HEAD"))
+    private void startStrongholdGen(World world, CallbackInfo ci) {
         //start stronghold gen on nether entry to prevent lag when throwing eyes
-        if(world.getDimensionRegistryKey()!= DimensionType.OVERWORLD_REGISTRY_KEY&&world instanceof ServerWorld) {
+        if (world.getDimensionRegistryKey() != DimensionType.OVERWORLD_REGISTRY_KEY && world instanceof ServerWorld) {
             MinecraftServer server = this.getServer();
-            if(server!=null) {
+            if (server != null) {
                 for (ServerWorld serverWorld : server.getWorlds()) {
-                    StrongholdGen strongholdGen = ((ChunkGeneratorInterface) serverWorld.getChunkManager().getChunkGenerator()).getStrongholdGen();
+                    StrongholdGen strongholdGen = ((ChunkGeneratorInterface) serverWorld.getChunkManager().getChunkGenerator()).lazyStronghold$getStrongholdGen();
                     if (strongholdGen != null) {
                         if (!strongholdGen.started) {
                             strongholdGen.start();


### PR DESCRIPTION
Copying the biomesource causes a lot of allocations on the SeedQueueThread (mainly because caches are initialized), by just delaying it until actual use this work can be skipped during resetting.