### PR TITLE
BiomeSource Copy Optimizations, some upgradling+formatting & SeedQueue compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,18 +7,6 @@ version = project.mod_version
 group = project.maven_group
 
 repositories {
-    // Add repositories to retrieve artifacts from in here.
-    // You should only use this when depending on other mods because
-    // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
-    // See https://docs.gradle.org/current/userguide/declaring_repositories.html
-    // for more information about repositories.
-}
-
-configurations {
-    modIncludeImplementation
-
-    include.extendsFrom modIncludeImplementation
-    modImplementation.extendsFrom modIncludeImplementation
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # check these on https://modmuss50.me/fabric.html
 minecraft_version=1.15.2
 yarn_mappings=1.15.2+build.17
-loader_version=0.13.3
+loader_version=0.16.14
 # Mod Properties
 mod_version=1.1.3
 maven_group=com.gregor0410

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/gregor0410/lazystronghold/ChunkGeneratorInterface.java
+++ b/src/main/java/com/gregor0410/lazystronghold/ChunkGeneratorInterface.java
@@ -1,5 +1,5 @@
 package com.gregor0410.lazystronghold;
 
 public interface ChunkGeneratorInterface {
-    StrongholdGen getStrongholdGen();
+    StrongholdGen lazyStronghold$getStrongholdGen();
 }

--- a/src/main/java/com/gregor0410/lazystronghold/IBiomeSource.java
+++ b/src/main/java/com/gregor0410/lazystronghold/IBiomeSource.java
@@ -3,5 +3,5 @@ package com.gregor0410.lazystronghold;
 import net.minecraft.world.biome.source.BiomeSource;
 
 public interface IBiomeSource {
-    BiomeSource copy();
+    BiomeSource lazyStronghold$copy();
 }

--- a/src/main/java/com/gregor0410/lazystronghold/Lazystronghold.java
+++ b/src/main/java/com/gregor0410/lazystronghold/Lazystronghold.java
@@ -8,10 +8,12 @@ import org.apache.logging.log4j.Logger;
 public class Lazystronghold implements ModInitializer {
     private static final String MOD_NAME = "LazyStronghold";
     public static Logger LOGGER = LogManager.getLogger();
+
     @Override
     public void onInitialize() {
 
     }
+
     public static void log(Level level, String message) {
         LOGGER.log(level, "[" + MOD_NAME + "] " + message);
     }

--- a/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
+++ b/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
@@ -1,32 +1,26 @@
 package com.gregor0410.lazystronghold;
 
 import com.gregor0410.lazystronghold.mixin.StrongholdFeatureAccess;
-import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.biome.source.BiomeSource;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
 import net.minecraft.world.gen.feature.StructureFeature;
 import org.apache.logging.log4j.Level;
 
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class StrongholdGen implements Runnable {
     private final Thread thread;
     private final ChunkGenerator<?> generator;
     public BiomeSource biomeSource;
-    public CopyOnWriteArrayList<ChunkPos> strongholds;
     public boolean started;
     public final AtomicBoolean completedSignal;
     public boolean shouldStop;
-    public int count;
 
-    public StrongholdGen(ChunkGenerator<?> generator, CopyOnWriteArrayList<ChunkPos> strongholds) {
+    public StrongholdGen(ChunkGenerator<?> generator) {
         this.started = false;
         this.shouldStop = false;
         this.completedSignal = new AtomicBoolean(false);
         this.thread = new Thread(this, "Stronghold thread");
-        this.count = generator.getConfig().getStrongholdCount();
-        this.strongholds = strongholds;
         this.generator = generator;
     }
 
@@ -48,11 +42,7 @@ public class StrongholdGen implements Runnable {
         if (this.shouldStop) {
             Lazystronghold.log(Level.INFO, "Stronghold thread stopped early");
         } else {
-            if (this.strongholds.size() != this.count) {
-                Lazystronghold.log(Level.ERROR, "Only " + this.strongholds.size() + " strongholds generated!");
-            } else {
-                Lazystronghold.log(Level.INFO, "Generated " + this.count + " strongholds.");
-            }
+            Lazystronghold.log(Level.INFO, "Generated strongholds.");
         }
         synchronized (completedSignal) {
             completedSignal.set(true);

--- a/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
+++ b/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class StrongholdGen implements Runnable {
     private final Thread thread;
     private final ChunkGenerator<?> generator;
-    public final BiomeSource biomeSource;
+    public BiomeSource biomeSource;
     public CopyOnWriteArrayList<ChunkPos> strongholds;
     public boolean started;
     public final AtomicBoolean completedSignal;
@@ -24,7 +24,6 @@ public class StrongholdGen implements Runnable {
         this.started = false;
         this.shouldStop = false;
         this.completedSignal = new AtomicBoolean(false);
-        this.biomeSource = ((IBiomeSource) generator.getBiomeSource()).lazyStronghold$copy(); //create new biome source instance for thread safety
         this.thread = new Thread(this, "Stronghold thread");
         this.count = generator.getConfig().getStrongholdCount();
         this.strongholds = strongholds;
@@ -33,6 +32,7 @@ public class StrongholdGen implements Runnable {
 
     public void start() {
         this.started = true;
+        this.biomeSource = ((IBiomeSource) this.generator.getBiomeSource()).lazyStronghold$copy(); //create new biome source instance for thread safety
         this.thread.start();
     }
 
@@ -58,5 +58,6 @@ public class StrongholdGen implements Runnable {
             completedSignal.set(true);
             completedSignal.notifyAll();
         }
+        this.biomeSource = null;
     }
 }

--- a/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
+++ b/src/main/java/com/gregor0410/lazystronghold/StrongholdGen.java
@@ -2,62 +2,59 @@ package com.gregor0410.lazystronghold;
 
 import com.gregor0410.lazystronghold.mixin.StrongholdFeatureAccess;
 import net.minecraft.util.math.ChunkPos;
-import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.source.BiomeSource;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
 import net.minecraft.world.gen.feature.StructureFeature;
 import org.apache.logging.log4j.Level;
 
-import java.util.ArrayList;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class StrongholdGen implements Runnable {
     private final Thread thread;
-    private final ChunkGenerator generator;
+    private final ChunkGenerator<?> generator;
     public final BiomeSource biomeSource;
-    private final long seed;
-    private ArrayList<Biome> list;
     public CopyOnWriteArrayList<ChunkPos> strongholds;
     public boolean started;
     public final AtomicBoolean completedSignal;
     public boolean shouldStop;
     public int count;
 
-
-    public StrongholdGen(ChunkGenerator<?> generator, long seed, CopyOnWriteArrayList<ChunkPos> strongholds){
-        this.started=false;
+    public StrongholdGen(ChunkGenerator<?> generator, CopyOnWriteArrayList<ChunkPos> strongholds) {
+        this.started = false;
         this.shouldStop = false;
         this.completedSignal = new AtomicBoolean(false);
-        this.seed = seed;
-        this.biomeSource = ((IBiomeSource)generator.getBiomeSource()).copy(); //create new biome source instance for thread safety
-        this.thread = new Thread(this,"Stronghold thread");
+        this.biomeSource = ((IBiomeSource) generator.getBiomeSource()).lazyStronghold$copy(); //create new biome source instance for thread safety
+        this.thread = new Thread(this, "Stronghold thread");
         this.count = generator.getConfig().getStrongholdCount();
         this.strongholds = strongholds;
         this.generator = generator;
     }
-    public void start(){
+
+    public void start() {
         this.started = true;
         this.thread.start();
     }
-    public void stop(){
-        this.shouldStop=true;
+
+    public void stop() {
+        this.shouldStop = true;
     }
+
     @Override
     public void run() {
-        Lazystronghold.log(Level.INFO,"Started stronghold gen thread");
-        ((StrongholdFeatureAccess)StructureFeature.STRONGHOLD).invokeInvalidateState();
-        ((StrongholdFeatureAccess)StructureFeature.STRONGHOLD).invokeInitialize(this.generator);
-        if(this.shouldStop){
-            Lazystronghold.log(Level.INFO,"Stronghold thread stopped early");
-        }else {
+        Lazystronghold.log(Level.INFO, "Started stronghold gen thread");
+        ((StrongholdFeatureAccess) StructureFeature.STRONGHOLD).invokeInvalidateState();
+        ((StrongholdFeatureAccess) StructureFeature.STRONGHOLD).invokeInitialize(this.generator);
+        if (this.shouldStop) {
+            Lazystronghold.log(Level.INFO, "Stronghold thread stopped early");
+        } else {
             if (this.strongholds.size() != this.count) {
                 Lazystronghold.log(Level.ERROR, "Only " + this.strongholds.size() + " strongholds generated!");
             } else {
                 Lazystronghold.log(Level.INFO, "Generated " + this.count + " strongholds.");
             }
         }
-        synchronized (completedSignal){
+        synchronized (completedSignal) {
             completedSignal.set(true);
             completedSignal.notifyAll();
         }

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/ChunkGeneratorMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/ChunkGeneratorMixin.java
@@ -19,7 +19,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Objects;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 @Mixin(ChunkGenerator.class)
 public abstract class ChunkGeneratorMixin implements ChunkGeneratorInterface {
@@ -30,8 +29,6 @@ public abstract class ChunkGeneratorMixin implements ChunkGeneratorInterface {
 
     @Unique
     private StrongholdGen strongholdGen = null;
-    @Unique
-    private final CopyOnWriteArrayList<ChunkPos> strongholds = new CopyOnWriteArrayList<>();
 
     @Mutable
     @Shadow
@@ -41,7 +38,7 @@ public abstract class ChunkGeneratorMixin implements ChunkGeneratorInterface {
     @Inject(method = "<init>", at = @At("TAIL"))
     private void init(CallbackInfo ci) {
         if (((Object) this instanceof OverworldChunkGenerator || (Object) this instanceof FlatChunkGenerator) && this.config.getStrongholdCount() > 0) {
-            this.strongholdGen = new StrongholdGen((ChunkGenerator<?>) (Object) this, this.strongholds);
+            this.strongholdGen = new StrongholdGen((ChunkGenerator<?>) (Object) this);
         }
     }
 

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/ChunkGeneratorMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/ChunkGeneratorMixin.java
@@ -5,7 +5,6 @@ import com.gregor0410.lazystronghold.StrongholdGen;
 import net.minecraft.structure.StructureManager;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
-import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.source.BiomeAccess;
 import net.minecraft.world.chunk.Chunk;
@@ -13,10 +12,7 @@ import net.minecraft.world.gen.chunk.ChunkGenerator;
 import net.minecraft.world.gen.chunk.ChunkGeneratorConfig;
 import net.minecraft.world.gen.chunk.FlatChunkGenerator;
 import net.minecraft.world.gen.chunk.OverworldChunkGenerator;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Mutable;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -26,46 +22,39 @@ import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 @Mixin(ChunkGenerator.class)
-public class ChunkGeneratorMixin implements ChunkGeneratorInterface {
-    @Mutable
-    @Shadow @Final protected ChunkGeneratorConfig config;
-    @Shadow @Final protected long seed;
-    @Shadow @Final protected IWorld world;
-    private StrongholdGen strongholdGen = null;
-    private final CopyOnWriteArrayList<ChunkPos> strongholds = new CopyOnWriteArrayList<ChunkPos>();
+public abstract class ChunkGeneratorMixin implements ChunkGeneratorInterface {
+    @Unique
     private static final double ROOT_2 = Math.sqrt(2);
+    @Unique
     private static final int PADDING = 10;
 
+    @Unique
+    private StrongholdGen strongholdGen = null;
+    @Unique
+    private final CopyOnWriteArrayList<ChunkPos> strongholds = new CopyOnWriteArrayList<>();
 
-    @Inject(method="<init>",at=@At("TAIL"))
-    private void init(CallbackInfo ci){
-        if(((Object)this instanceof OverworldChunkGenerator || (Object)this instanceof FlatChunkGenerator) && this.config.getStrongholdCount()>0){
-            this.strongholdGen = new StrongholdGen((ChunkGenerator<?>) (Object) this,this.seed,this.strongholds);
+    @Mutable
+    @Shadow
+    @Final
+    protected ChunkGeneratorConfig config;
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void init(CallbackInfo ci) {
+        if (((Object) this instanceof OverworldChunkGenerator || (Object) this instanceof FlatChunkGenerator) && this.config.getStrongholdCount() > 0) {
+            this.strongholdGen = new StrongholdGen((ChunkGenerator<?>) (Object) this, this.strongholds);
         }
     }
 
-
-    private int minSquaredDistance(){
-        double d = 2.75 * this.config.getStrongholdDistance() * 16 - 128 * ROOT_2;
-        if(d <0) return 0;
-        return (int) Math.pow((int) d >>4,2);
-    }
-    private int minSquaredDistanceWithPadding(){
-        double d = 2.75 * this.config.getStrongholdDistance() * 16 - 128 * ROOT_2;
-        if(d - PADDING * 16 <0) return 0;
-        return (int) Math.pow(((int) d >>4)-PADDING,2);
-    }
-
-    @Inject(method="setStructureStarts",at=@At("HEAD"))
+    @Inject(method = "setStructureStarts", at = @At("HEAD"))
     private void waitForStrongholds(BiomeAccess biomeAccess, Chunk chunk, ChunkGenerator<?> chunkGenerator, StructureManager structureManager, CallbackInfo ci) throws InterruptedException {
-        if(this.strongholdGen!=null){
+        if (this.strongholdGen != null) {
             ChunkPos chunkPos = chunk.getPos();
             int squaredDistance = (chunkPos.x * chunkPos.x) + (chunkPos.z * chunkPos.z);
-            if(squaredDistance >=minSquaredDistanceWithPadding()) {
+            if (squaredDistance >= minSquaredDistanceWithPadding()) {
                 if (!strongholdGen.started) strongholdGen.start();
-                if(squaredDistance>=minSquaredDistance()){
-                    synchronized (strongholdGen.completedSignal){
-                        while(!strongholdGen.completedSignal.get()){
+                if (squaredDistance >= minSquaredDistance()) {
+                    synchronized (strongholdGen.completedSignal) {
+                        while (!strongholdGen.completedSignal.get()) {
                             strongholdGen.completedSignal.wait();
                         }
                     }
@@ -74,22 +63,34 @@ public class ChunkGeneratorMixin implements ChunkGeneratorInterface {
         }
     }
 
-    @Inject(method="locateStructure",at=@At("HEAD"))
+    @Inject(method = "locateStructure", at = @At("HEAD"))
     private void waitForStrongholds2(World world, String id, BlockPos center, int radius, boolean skipExistingChunks, CallbackInfoReturnable<BlockPos> cir) throws InterruptedException {
-        if(Objects.equals(id, "Stronghold") && this.strongholdGen!=null){
-            if(!strongholdGen.started)strongholdGen.start();
-            synchronized (strongholdGen.completedSignal){
-                while(!strongholdGen.completedSignal.get()){
+        if (Objects.equals(id, "Stronghold") && this.strongholdGen != null) {
+            if (!strongholdGen.started) strongholdGen.start();
+            synchronized (strongholdGen.completedSignal) {
+                while (!strongholdGen.completedSignal.get()) {
                     strongholdGen.completedSignal.wait();
                 }
             }
         }
     }
 
-
-    @Override
-    public StrongholdGen getStrongholdGen() {
-        return this.strongholdGen;
+    @Unique
+    private int minSquaredDistance() {
+        double d = 2.75 * this.config.getStrongholdDistance() * 16 - 128 * ROOT_2;
+        if (d < 0) return 0;
+        return (int) Math.pow((int) d >> 4, 2);
     }
 
+    @Unique
+    private int minSquaredDistanceWithPadding() {
+        double d = 2.75 * this.config.getStrongholdDistance() * 16 - 128 * ROOT_2;
+        if (d - PADDING * 16 < 0) return 0;
+        return (int) Math.pow(((int) d >> 4) - PADDING, 2);
+    }
+
+    @Override
+    public StrongholdGen lazyStronghold$getStrongholdGen() {
+        return this.strongholdGen;
+    }
 }

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/EntityMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/EntityMixin.java
@@ -15,16 +15,17 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Entity.class)
 public abstract class EntityMixin {
-    @Shadow public abstract @Nullable MinecraftServer getServer();
+    @Shadow
+    public abstract @Nullable MinecraftServer getServer();
 
-    @Inject(method="setWorld",at=@At("HEAD"))
-    private void startStrongholdGen(World world, CallbackInfo ci){
+    @Inject(method = "setWorld", at = @At("HEAD"))
+    private void startStrongholdGen(World world, CallbackInfo ci) {
         //start stronghold gen on nether entry to prevent lag when throwing eyes
-        if(world.getDimension().isNether() &&world instanceof ServerWorld) {
+        if (world.getDimension().isNether() && world instanceof ServerWorld) {
             MinecraftServer server = this.getServer();
-            if(server!=null) {
+            if (server != null) {
                 for (ServerWorld serverWorld : server.getWorlds()) {
-                    StrongholdGen strongholdGen = ((ChunkGeneratorInterface) serverWorld.getChunkManager().getChunkGenerator()).getStrongholdGen();
+                    StrongholdGen strongholdGen = ((ChunkGeneratorInterface) serverWorld.getChunkManager().getChunkGenerator()).lazyStronghold$getStrongholdGen();
                     if (strongholdGen != null) {
                         if (!strongholdGen.started) {
                             strongholdGen.start();

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/FixedBiomeSourceMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/FixedBiomeSourceMixin.java
@@ -5,21 +5,23 @@ import net.minecraft.world.biome.source.BiomeSource;
 import net.minecraft.world.biome.source.FixedBiomeSource;
 import net.minecraft.world.biome.source.FixedBiomeSourceConfig;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(FixedBiomeSource.class)
-public class FixedBiomeSourceMixin implements IBiomeSource {
-
+public abstract class FixedBiomeSourceMixin implements IBiomeSource {
+    @Unique
     private FixedBiomeSourceConfig config;
 
-    @Inject(method="<init>",at=@At("TAIL"))
-    private void init(FixedBiomeSourceConfig config, CallbackInfo ci){
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void init(FixedBiomeSourceConfig config, CallbackInfo ci) {
         this.config = config;
     }
+
     @Override
-    public BiomeSource copy() {
-        return new FixedBiomeSource(this.config) ;
+    public BiomeSource lazyStronghold$copy() {
+        return new FixedBiomeSource(this.config);
     }
 }

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/MinecraftServerMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/MinecraftServerMixin.java
@@ -13,6 +13,7 @@ import net.minecraft.world.level.LevelProperties;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -20,28 +21,32 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.Map;
 
 @Mixin(MinecraftServer.class)
-public class MinecraftServerMixin {
-    @Shadow @Final private Map<DimensionType, ServerWorld> worlds;
+public abstract class MinecraftServerMixin {
+    @Shadow
+    @Final
+    private Map<DimensionType, ServerWorld> worlds;
+    @Shadow
+    private int ticks;
 
-    @Shadow private int ticks;
-
+    @Unique
     private boolean isNewWorld;
 
-    @Inject(method ="shutdown",at=@At("HEAD"))
-    private void stopStrongholdThreads(CallbackInfo ci){
-        this.worlds.values().forEach(world->{
+    @Inject(method = "shutdown", at = @At("HEAD"))
+    private void stopStrongholdThreads(CallbackInfo ci) {
+        this.worlds.values().forEach(world -> {
             ChunkGenerator<?> chunkGenerator = world.getChunkManager().getChunkGenerator();
-            StrongholdGen strongholdGen = ((ChunkGeneratorInterface)chunkGenerator).getStrongholdGen();
-            if(strongholdGen!=null){
+            StrongholdGen strongholdGen = ((ChunkGeneratorInterface) chunkGenerator).lazyStronghold$getStrongholdGen();
+            if (strongholdGen != null) {
                 strongholdGen.stop();
             }
         });
     }
-    @Inject(method="prepareStartRegion",at=@At("HEAD"))
-    private void startStrongholdThreadIfNotNewWorld(CallbackInfo ci){
-        if(!this.isNewWorld){
-            this.worlds.values().forEach(world->{
-                StrongholdGen strongholdGen = ((ChunkGeneratorInterface) world.getChunkManager().getChunkGenerator()).getStrongholdGen();
+
+    @Inject(method = "prepareStartRegion", at = @At("HEAD"))
+    private void startStrongholdThreadIfNotNewWorld(CallbackInfo ci) {
+        if (!this.isNewWorld) {
+            this.worlds.values().forEach(world -> {
+                StrongholdGen strongholdGen = ((ChunkGeneratorInterface) world.getChunkManager().getChunkGenerator()).lazyStronghold$getStrongholdGen();
                 if (strongholdGen != null) {
                     if (!strongholdGen.started) {
                         strongholdGen.start();
@@ -51,11 +56,11 @@ public class MinecraftServerMixin {
         }
     }
 
-    @Inject(method="prepareStartRegion",at=@At("TAIL"))
-    private void waitForStrongholdThreadIfNotNewWorld(CallbackInfo ci){
-        if(!this.isNewWorld){
-            this.worlds.values().forEach(world->{
-                StrongholdGen strongholdGen = ((ChunkGeneratorInterface) world.getChunkManager().getChunkGenerator()).getStrongholdGen();
+    @Inject(method = "prepareStartRegion", at = @At("TAIL"))
+    private void waitForStrongholdThreadIfNotNewWorld(CallbackInfo ci) {
+        if (!this.isNewWorld) {
+            this.worlds.values().forEach(world -> {
+                StrongholdGen strongholdGen = ((ChunkGeneratorInterface) world.getChunkManager().getChunkGenerator()).lazyStronghold$getStrongholdGen();
                 if (strongholdGen != null) {
                     if (!strongholdGen.started) {
                         strongholdGen.start();
@@ -74,12 +79,12 @@ public class MinecraftServerMixin {
         }
     }
 
-    @Inject(method="tick",at=@At("HEAD"))
-    private void startStrongholdThread(CallbackInfo ci){
+    @Inject(method = "tick", at = @At("HEAD"))
+    private void startStrongholdThread(CallbackInfo ci) {
         //start the thread after 20 ticks so instances paused on world load by reset macros don't have thread started until the player unpauses
-        if(this.ticks==20){
-            this.worlds.values().forEach(world->{
-                StrongholdGen strongholdGen = ((ChunkGeneratorInterface) world.getChunkManager().getChunkGenerator()).getStrongholdGen();
+        if (this.ticks == 20) {
+            this.worlds.values().forEach(world -> {
+                StrongholdGen strongholdGen = ((ChunkGeneratorInterface) world.getChunkManager().getChunkGenerator()).lazyStronghold$getStrongholdGen();
                 if (strongholdGen != null) {
                     if (!strongholdGen.started) {
                         strongholdGen.start();
@@ -88,8 +93,9 @@ public class MinecraftServerMixin {
             });
         }
     }
-    @Inject(method="createWorlds",at=@At("HEAD"))
-    private void checkIfNewWorld(WorldSaveHandler worldSaveHandler, LevelProperties properties, LevelInfo levelInfo, WorldGenerationProgressListener worldGenerationProgressListener, CallbackInfo ci){
+
+    @Inject(method = "createWorlds", at = @At("HEAD"))
+    private void checkIfNewWorld(WorldSaveHandler worldSaveHandler, LevelProperties properties, LevelInfo levelInfo, WorldGenerationProgressListener worldGenerationProgressListener, CallbackInfo ci) {
         this.isNewWorld = !properties.isInitialized();
     }
 }

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/StrongholdFeatureAccess.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/StrongholdFeatureAccess.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 public interface StrongholdFeatureAccess {
     @Invoker
     void invokeInitialize(ChunkGenerator<?> chunkGenerator);
+
     @Invoker
     void invokeInvalidateState();
 }

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/StrongholdFeatureMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/StrongholdFeatureMixin.java
@@ -2,19 +2,12 @@ package com.gregor0410.lazystronghold.mixin;
 
 import com.gregor0410.lazystronghold.ChunkGeneratorInterface;
 import com.gregor0410.lazystronghold.StrongholdGen;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
-import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.source.BiomeAccess;
 import net.minecraft.world.biome.source.BiomeSource;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
-import net.minecraft.world.gen.chunk.ChunkGeneratorConfig;
 import net.minecraft.world.gen.feature.StrongholdFeature;
-import org.jetbrains.annotations.Nullable;
-import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -25,24 +18,12 @@ import java.util.Random;
 
 @Mixin(StrongholdFeature.class)
 public abstract class StrongholdFeatureMixin {
-    @Shadow
-    private ChunkPos[] startPositions;
 
     @Inject(method = "shouldStartAt", at = @At("HEAD"), cancellable = true)
     private void shouldStartAt(BiomeAccess biomeAccess, ChunkGenerator<?> chunkGenerator, Random random, int chunkZ, int i, Biome biome, CallbackInfoReturnable<Boolean> cir) {
         StrongholdGen strongholdGen = ((ChunkGeneratorInterface) chunkGenerator).lazyStronghold$getStrongholdGen();
-        if (strongholdGen != null && strongholdGen.completedSignal.get()) {
-            this.startPositions = strongholdGen.strongholds.toArray(new ChunkPos[0]);
-        } else {
+        if (strongholdGen != null && !strongholdGen.completedSignal.get()) {
             cir.setReturnValue(false);
-        }
-    }
-
-    @Inject(method = "locateStructure", at = @At("HEAD"))
-    private void setStartPositions(World world, ChunkGenerator<? extends ChunkGeneratorConfig> chunkGenerator, BlockPos blockPos, int i, boolean skipExistingChunks, CallbackInfoReturnable<@Nullable BlockPos> cir) {
-        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) chunkGenerator).lazyStronghold$getStrongholdGen();
-        if (strongholdGen != null && strongholdGen.completedSignal.get()) {
-            this.startPositions = strongholdGen.strongholds.toArray(new ChunkPos[0]);
         }
     }
 
@@ -52,14 +33,6 @@ public abstract class StrongholdFeatureMixin {
 
     @Redirect(method = "locateStructure", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/gen/feature/StrongholdFeature;initialize(Lnet/minecraft/world/gen/chunk/ChunkGenerator;)V"))
     private void cancelStrongholdGen2(StrongholdFeature instance, ChunkGenerator<?> chunkGenerator) {
-    }
-
-    @Redirect(method="initialize",at=@At(value="FIELD",opcode= Opcodes.GETFIELD,args="array=set",target = "Lnet/minecraft/world/gen/feature/StrongholdFeature;startPositions:[Lnet/minecraft/util/math/ChunkPos;"))
-    private void addToStrongholds(ChunkPos[] array, int index, ChunkPos value, ChunkGenerator<?> chunkGenerator) {
-        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) chunkGenerator).lazyStronghold$getStrongholdGen();
-        if (strongholdGen != null) {
-            strongholdGen.strongholds.add(value);
-        }
     }
 
     @Redirect(method = "initialize", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/gen/chunk/ChunkGenerator;getBiomeSource()Lnet/minecraft/world/biome/source/BiomeSource;"))

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/StrongholdFeatureMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/StrongholdFeatureMixin.java
@@ -24,66 +24,58 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.util.Random;
 
 @Mixin(StrongholdFeature.class)
-public class StrongholdFeatureMixin {
-    @Shadow private ChunkPos[] startPositions;
-    private ChunkGenerator<?> generator;
+public abstract class StrongholdFeatureMixin {
+    @Shadow
+    private ChunkPos[] startPositions;
 
-    @Inject(method="shouldStartAt",at=@At("HEAD"),cancellable = true)
-    private void shouldStartAt(BiomeAccess biomeAccess, ChunkGenerator<?> chunkGenerator, Random random, int chunkZ, int i, Biome biome, CallbackInfoReturnable<Boolean> cir){
-        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) chunkGenerator).getStrongholdGen();
-        if(strongholdGen != null&&strongholdGen.completedSignal.get()){
-            this.startPositions = strongholdGen.strongholds.toArray(this.startPositions);
-        }else{
+    @Inject(method = "shouldStartAt", at = @At("HEAD"), cancellable = true)
+    private void shouldStartAt(BiomeAccess biomeAccess, ChunkGenerator<?> chunkGenerator, Random random, int chunkZ, int i, Biome biome, CallbackInfoReturnable<Boolean> cir) {
+        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) chunkGenerator).lazyStronghold$getStrongholdGen();
+        if (strongholdGen != null && strongholdGen.completedSignal.get()) {
+            this.startPositions = strongholdGen.strongholds.toArray(new ChunkPos[0]);
+        } else {
             cir.setReturnValue(false);
         }
     }
 
-    @Inject(method = "locateStructure",at=@At("HEAD"))
-    private void setStartPositions(World world, ChunkGenerator<? extends ChunkGeneratorConfig> chunkGenerator, BlockPos blockPos, int i, boolean skipExistingChunks, CallbackInfoReturnable<@Nullable BlockPos> cir){
-        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) chunkGenerator).getStrongholdGen();
-        if(strongholdGen != null&&strongholdGen.completedSignal.get()){
-            this.startPositions = strongholdGen.strongholds.toArray(this.startPositions);
+    @Inject(method = "locateStructure", at = @At("HEAD"))
+    private void setStartPositions(World world, ChunkGenerator<? extends ChunkGeneratorConfig> chunkGenerator, BlockPos blockPos, int i, boolean skipExistingChunks, CallbackInfoReturnable<@Nullable BlockPos> cir) {
+        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) chunkGenerator).lazyStronghold$getStrongholdGen();
+        if (strongholdGen != null && strongholdGen.completedSignal.get()) {
+            this.startPositions = strongholdGen.strongholds.toArray(new ChunkPos[0]);
         }
     }
 
-
-    @Redirect(method="shouldStartAt",at=@At(value="INVOKE",target="Lnet/minecraft/world/gen/feature/StrongholdFeature;initialize(Lnet/minecraft/world/gen/chunk/ChunkGenerator;)V"))
-    private void cancelStrongholdGen(StrongholdFeature instance, ChunkGenerator<?> chunkGenerator){}
-
-    @Redirect(method="locateStructure",at=@At(value="INVOKE",target = "Lnet/minecraft/world/gen/feature/StrongholdFeature;initialize(Lnet/minecraft/world/gen/chunk/ChunkGenerator;)V"))
-    private void cancelStrongholdGen2(StrongholdFeature instance, ChunkGenerator<?> chunkGenerator){}
-
-    @Inject(method="initialize",at=@At("HEAD"))
-    private void setGenerator(ChunkGenerator<?> chunkGenerator, CallbackInfo ci){
-        this.generator = chunkGenerator;
+    @Redirect(method = "shouldStartAt", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/gen/feature/StrongholdFeature;initialize(Lnet/minecraft/world/gen/chunk/ChunkGenerator;)V"))
+    private void cancelStrongholdGen(StrongholdFeature instance, ChunkGenerator<?> chunkGenerator) {
     }
 
-    @Redirect(method="initialize",at=@At(value="FIELD",opcode=Opcodes.GETFIELD,args="array=set",target = "Lnet/minecraft/world/gen/feature/StrongholdFeature;startPositions:[Lnet/minecraft/util/math/ChunkPos;"))
-    private void addToStrongholds(ChunkPos[] array, int index, ChunkPos value){
-        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) this.generator).getStrongholdGen();
-        if(strongholdGen!=null) {
+    @Redirect(method = "locateStructure", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/gen/feature/StrongholdFeature;initialize(Lnet/minecraft/world/gen/chunk/ChunkGenerator;)V"))
+    private void cancelStrongholdGen2(StrongholdFeature instance, ChunkGenerator<?> chunkGenerator) {
+    }
+
+    @Redirect(method="initialize",at=@At(value="FIELD",opcode= Opcodes.GETFIELD,args="array=set",target = "Lnet/minecraft/world/gen/feature/StrongholdFeature;startPositions:[Lnet/minecraft/util/math/ChunkPos;"))
+    private void addToStrongholds(ChunkPos[] array, int index, ChunkPos value, ChunkGenerator<?> chunkGenerator) {
+        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) chunkGenerator).lazyStronghold$getStrongholdGen();
+        if (strongholdGen != null) {
             strongholdGen.strongholds.add(value);
         }
     }
 
-    @Redirect(method="initialize",at=@At(value="INVOKE",target="Lnet/minecraft/world/gen/chunk/ChunkGenerator;getBiomeSource()Lnet/minecraft/world/biome/source/BiomeSource;"))
-    private BiomeSource getBiomeSource(ChunkGenerator<?> instance){
-        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) this.generator).getStrongholdGen();
-        if(strongholdGen!=null){
+    @Redirect(method = "initialize", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/gen/chunk/ChunkGenerator;getBiomeSource()Lnet/minecraft/world/biome/source/BiomeSource;"))
+    private BiomeSource getBiomeSource(ChunkGenerator<?> generator) {
+        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) generator).lazyStronghold$getStrongholdGen();
+        if (strongholdGen != null) {
             return strongholdGen.biomeSource;
-        }else{
-            return instance.getBiomeSource(); //this should never be executed but i've left it in to prevent crashing
         }
+        return generator.getBiomeSource(); //this should never be executed but i've left it in to prevent crashing
     }
 
-    @Inject(method="initialize",at=@At(value="INVOKE",target = "Lnet/minecraft/world/biome/source/BiomeSource;locateBiome(IIIILjava/util/List;Ljava/util/Random;)Lnet/minecraft/util/math/BlockPos;"),cancellable = true)
-    private void stopStrongholdGen(ChunkGenerator<?> chunkGenerator, CallbackInfo ci){
-        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) this.generator).getStrongholdGen();
-        if(strongholdGen!=null&& strongholdGen.shouldStop){
+    @Inject(method = "initialize", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/biome/source/BiomeSource;locateBiome(IIIILjava/util/List;Ljava/util/Random;)Lnet/minecraft/util/math/BlockPos;"), cancellable = true)
+    private void stopStrongholdGen(ChunkGenerator<?> generator, CallbackInfo ci) {
+        StrongholdGen strongholdGen = ((ChunkGeneratorInterface) generator).lazyStronghold$getStrongholdGen();
+        if (strongholdGen != null && strongholdGen.shouldStop) {
             ci.cancel();
         }
     }
-
-
-
 }

--- a/src/main/java/com/gregor0410/lazystronghold/mixin/VanillaLayeredBiomeSourceMixin.java
+++ b/src/main/java/com/gregor0410/lazystronghold/mixin/VanillaLayeredBiomeSourceMixin.java
@@ -5,22 +5,23 @@ import net.minecraft.world.biome.source.BiomeSource;
 import net.minecraft.world.biome.source.VanillaLayeredBiomeSource;
 import net.minecraft.world.biome.source.VanillaLayeredBiomeSourceConfig;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(VanillaLayeredBiomeSource.class)
-public class VanillaLayeredBiomeSourceMixin implements IBiomeSource {
-
+public abstract class VanillaLayeredBiomeSourceMixin implements IBiomeSource {
+    @Unique
     private VanillaLayeredBiomeSourceConfig config;
 
-    @Inject(method="<init>",at=@At("TAIL"))
-    private void init(VanillaLayeredBiomeSourceConfig config, CallbackInfo ci){
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void init(VanillaLayeredBiomeSourceConfig config, CallbackInfo ci) {
         this.config = config;
     }
 
     @Override
-    public BiomeSource copy() {
+    public BiomeSource lazyStronghold$copy() {
         return new VanillaLayeredBiomeSource(this.config);
     }
 }


### PR DESCRIPTION
see https://github.com/Gregor0410/LazyStronghold/pull/7

SeedQueue for 1.15.2 has to move the strongholds array from the `StrongholdFeature` into the `ChunkGenerator`, which it does by redirecting any accesses to the array. However this would break with LazyStronghold trying to redirect the array puts to its own list, which isnt even required in the first place so we can just remove that step.
Any accesses of the array will wait for stronghold gen to be finished first anyway.